### PR TITLE
Proposal for sending failure items using the new failure event hooks for instant notification

### DIFF
--- a/Email/EmailCommon.cs
+++ b/Email/EmailCommon.cs
@@ -51,10 +51,10 @@ namespace DaleGhent.NINA.GroundStation.Email {
                 await smtp.DisconnectAsync(true, ct);
             } catch (SocketException ex) {
                 Logger.Error($"SmtpEmail: Connection to {SmtpHostName}:{SmtpHostPort} failed: {ex.SocketErrorCode}: {ex.Message}");
-                throw ex;
+                throw;
             } catch (AuthenticationException ex) {
                 Logger.Error($"SendEmail: User {SmtpUsername} failed to authenticate with {SmtpHostName}:{SmtpHostPort}");
-                throw ex;
+                throw;
             }
         }
 

--- a/Ground Station.csproj
+++ b/Ground Station.csproj
@@ -178,37 +178,37 @@
       <Version>3.1.1</Version>
     </PackageReference>
     <PackageReference Include="NINA.Astrometry">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="NINA.Core">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="NINA.Equipment">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="NINA.Image">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="NINA.MGEN">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="NINA.PlateSolving">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="NINA.Plugin">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="NINA.Profile">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="NINA.Sequencer">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="NINA.WPF.Base">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="NINACustomControlLibrary">
-      <Version>2.0.0.2050-preview3</Version>
+      <Version>2.0.1.2012-beta</Version>
     </PackageReference>
     <PackageReference Include="PushoverNET">
       <Version>1.0.28</Version>

--- a/Ground Station.sln
+++ b/Ground Station.sln
@@ -11,8 +11,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{738D56B5-DF32-4932-9344-883E9731D3AB}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{738D56B5-DF32-4932-9344-883E9731D3AB}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{738D56B5-DF32-4932-9344-883E9731D3AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{738D56B5-DF32-4932-9344-883E9731D3AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{738D56B5-DF32-4932-9344-883E9731D3AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{738D56B5-DF32-4932-9344-883E9731D3AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/MQTT/MqttClient.cs
+++ b/MQTT/MqttClient.cs
@@ -129,7 +129,7 @@ namespace DaleGhent.NINA.GroundStation.Mqtt {
                 return;
             } catch (Exception ex) {
                 Logger.Error($"Error connecting to broker: {ex.Message}");
-                throw ex;
+                throw;
             }
         }
 
@@ -151,7 +151,7 @@ namespace DaleGhent.NINA.GroundStation.Mqtt {
                 }
             } catch (Exception ex) {
                 Logger.Error($"Error publishing to broker: {ex.Message}");
-                throw ex;
+                throw;
             }
 
             return result;
@@ -166,7 +166,7 @@ namespace DaleGhent.NINA.GroundStation.Mqtt {
                 }
             } catch (Exception ex) {
                 Logger.Error($"Error pinging broker: {ex.Message}");
-                throw ex;
+                throw;
             }
         }
 
@@ -182,7 +182,7 @@ namespace DaleGhent.NINA.GroundStation.Mqtt {
                 }
             } catch (Exception ex) {
                 Logger.Error($"Error disconnecting from broker: {ex.Message}");
-                throw ex;
+                throw;
             }
         }
 
@@ -204,7 +204,7 @@ namespace DaleGhent.NINA.GroundStation.Mqtt {
                 }
             } catch (Exception ex) {
                 Logger.Error($"Error subscribing to topic \"{Topic}\": {ex.Message}");
-                throw ex;
+                throw;
             }
         }
     }

--- a/MQTT/MqttCommon.cs
+++ b/MQTT/MqttCommon.cs
@@ -47,7 +47,7 @@ namespace DaleGhent.NINA.GroundStation.Mqtt {
                 await mqttClient.Disconnect(ct);
             } catch (Exception ex) {
                 Logger.Error($"Error sending to MQTT broker: {ex.Message}");
-                throw ex;
+                throw;
             }
         }
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -6,8 +6,8 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("1.11.0.0")]
-[assembly: AssemblyFileVersion("1.11.0.0")]
+[assembly: AssemblyVersion("1.11.1.0")]
+[assembly: AssemblyFileVersion("1.11.1.0")]
 
 // [MANDATORY] The name of your plugin
 [assembly: AssemblyTitle("Ground Station")]
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2022 Dale Ghent")]
 
 // The minimum Version of N.I.N.A. that this plugin is compatible with
-[assembly: AssemblyMetadata("MinimumApplicationVersion", "2.0.0.2050")]
+[assembly: AssemblyMetadata("MinimumApplicationVersion", "2.0.1.2012")]
 
 // The license your plugin code is using
 [assembly: AssemblyMetadata("License", "MPL-2.0")]
@@ -87,4 +87,4 @@ Help for this plugin may be found in the **#plugin-discussions** channel on the 
 // [Unused]
 [assembly: AssemblyTrademark("")]
 // [Unused]
-[assembly: AssemblyCulture("")] 
+[assembly: AssemblyCulture("")]

--- a/Pushover/PushoverCommon.cs
+++ b/Pushover/PushoverCommon.cs
@@ -49,7 +49,7 @@ namespace DaleGhent.NINA.GroundStation.Pushover {
                 }
             } catch (Exception ex) {
                 Logger.Error($"Error sending to Pushover: {ex.Message}");
-                throw ex;
+                throw;
             }
         }
 

--- a/Telegram/TelegramCommon.cs
+++ b/Telegram/TelegramCommon.cs
@@ -39,7 +39,7 @@ namespace DaleGhent.NINA.GroundStation.Telegram {
                 await bclient.SendTextMessageAsync(TelegramChatId, message, disableNotification: doNotNotify, cancellationToken: ct);
             } catch (Exception ex) {
                 Logger.Error($"Error sending to Telegram: {ex.Message}");
-                throw ex;
+                throw;
             }
         }
 

--- a/Utilities/FailedItem.cs
+++ b/Utilities/FailedItem.cs
@@ -10,6 +10,10 @@
 
 #endregion "copyright"
 
+using NINA.Core.Utility;
+using NINA.Sequencer;
+using NINA.Sequencer.SequenceItem;
+using NINA.Sequencer.Validations;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -25,6 +29,36 @@ namespace DaleGhent.NINA.GroundStation.Utilities {
         public string ParentName { get; set; } = string.Empty;
         public int Attempts { get; set; } = 0;
         public List<FailureReason> Reasons { get; set; } = new List<FailureReason>();
+
+        public static FailedItem FromEntity(ISequenceEntity entity, Exception failureReason) {
+            var failedItem = new FailedItem();
+
+            failedItem.Name = entity.Name;
+            failedItem.ParentName = entity?.Parent?.Name ?? "";
+            if (failedItem is ISequenceItem item) {
+                failedItem.Attempts = item.Attempts;
+            }
+            failedItem.Description = entity.Description;
+            failedItem.Category = entity.Category;
+
+            failedItem.Reasons.Add(new FailureReason() { Reason = failureReason.Message });
+
+            if (entity is IValidatable validatableItem && validatableItem.Issues.Count > 0) {
+                foreach (var issue in validatableItem.Issues) {
+                    if (!string.IsNullOrEmpty(issue)) {
+                        var reason = new FailureReason {
+                            Reason = issue
+                        };
+
+                        failedItem.Reasons.Add(reason);
+                    }
+                }
+            }
+
+            Logger.Debug($"Failed item: {failedItem.Name}, Reason count: {failedItem.Reasons.Count}");
+
+            return failedItem;
+        }
     }
 
     public class FailureReason {

--- a/Utilities/FailedItem.cs
+++ b/Utilities/FailedItem.cs
@@ -35,7 +35,8 @@ namespace DaleGhent.NINA.GroundStation.Utilities {
 
             failedItem.Name = entity.Name;
             failedItem.ParentName = entity?.Parent?.Name ?? "";
-            if (failedItem is ISequenceItem item) {
+            if (entity is ISequenceItem item) {
+                // Todo this will always report the total attempts, but we are more fine granular now and see a failure after one attempt already
                 failedItem.Attempts = item.Attempts;
             }
             failedItem.Description = entity.Description;

--- a/Utilities/Utilities.cs
+++ b/Utilities/Utilities.cs
@@ -14,6 +14,7 @@ using NINA.Astrometry;
 using NINA.Astrometry.Interfaces;
 using NINA.Core.Enum;
 using NINA.Core.Utility;
+using NINA.Sequencer;
 using NINA.Sequencer.Container;
 using NINA.Sequencer.SequenceItem;
 using NINA.Sequencer.Validations;
@@ -30,7 +31,7 @@ namespace DaleGhent.NINA.GroundStation.Utilities {
         internal const string RuntimeErrorMessage = "An unspecified failure occurred while running this item. Refer to NINA's log for details.";
         internal const int cancelTimeout = 10; // in seconds
 
-        internal static string ResolveTokens(string text, ISequenceItem sequenceItem = null, bool urlEncode = false) {
+        internal static string ResolveTokens(string text, ISequenceEntity sequenceItem = null, bool urlEncode = false) {
             IDeepSkyObject target = null;
 
             if (sequenceItem != null) {


### PR DESCRIPTION
The trigger execution can be completely skipped as the trigger is now more like a watcher.
Furthermore scanning for parent failure items or parallel containers is not necessary anymore, as the trigger will get notified directly on a failure and can instantly react on it.
Most importantly however is that it will not miss any failure event.

This PR covers Pushover Failure Trigger.
I can adapt the other triggers as well if you are fine with the changes made.