### PR TITLE
Update Utilities.cs for null fwheel.SelectedFilter

### DIFF
--- a/Utilities/Utilities.cs
+++ b/Utilities/Utilities.cs
@@ -139,13 +139,18 @@ namespace DaleGhent.NINA.GroundStation.Utilities {
             if (fwheel.Connected) {
                 text = text.Replace(@"$$FWHEEL_NAME$$", DoUrlEncode(urlEncode, fwheel.Name));
 
-                text = text.Replace(@"$$FWHEEL_FILTER_NAME$$", string.IsNullOrEmpty(fwheel.SelectedFilter.Name) ?
-                        DoUrlEncode(urlEncode, "----") :
-                        DoUrlEncode(urlEncode, fwheel.SelectedFilter.Name));
-
-                text = text.Replace(@"$$FWHEEL_FILTER_POS$$", fwheel.SelectedFilter.Position < 0 ?
-                        DoUrlEncode(urlEncode, "--") :
-                        DoUrlEncode(urlEncode, fwheel.SelectedFilter.Position.ToString(culture)));
+                if (fwheel.SelectedFilter != null) {
+                    text = text.Replace(@"$$FWHEEL_FILTER_NAME$$", string.IsNullOrEmpty(fwheel.SelectedFilter.Name) ?
+                            DoUrlEncode(urlEncode, "----") :
+                            DoUrlEncode(urlEncode, fwheel.SelectedFilter.Name));
+    
+                    text = text.Replace(@"$$FWHEEL_FILTER_POS$$", fwheel.SelectedFilter.Position < 0 ?
+                            DoUrlEncode(urlEncode, "--") :
+                            DoUrlEncode(urlEncode, fwheel.SelectedFilter.Position.ToString(culture)));
+                } else {
+                    text = text.Replace(@"$$FWHEEL_FILTER_NAME$$", DoUrlEncode(urlEncode, "----"));
+                    text = text.Replace(@"$$FWHEEL_FILTER_POS$$", DoUrlEncode(urlEncode, "--"));
+                }
             } else {
                 var pattern = new Regex(@"\$\$FWHEEL_[A-Z0-9_]+\$\$", RegexOptions.Compiled);
                 text = pattern.Replace(text, DoUrlEncode(urlEncode, "----"));

--- a/Utilities/Utilities.cs
+++ b/Utilities/Utilities.cs
@@ -139,18 +139,14 @@ namespace DaleGhent.NINA.GroundStation.Utilities {
             if (fwheel.Connected) {
                 text = text.Replace(@"$$FWHEEL_NAME$$", DoUrlEncode(urlEncode, fwheel.Name));
 
-                if (fwheel.SelectedFilter != null) {
-                    text = text.Replace(@"$$FWHEEL_FILTER_NAME$$", string.IsNullOrEmpty(fwheel.SelectedFilter.Name) ?
-                            DoUrlEncode(urlEncode, "----") :
-                            DoUrlEncode(urlEncode, fwheel.SelectedFilter.Name));
-    
-                    text = text.Replace(@"$$FWHEEL_FILTER_POS$$", fwheel.SelectedFilter.Position < 0 ?
-                            DoUrlEncode(urlEncode, "--") :
-                            DoUrlEncode(urlEncode, fwheel.SelectedFilter.Position.ToString(culture)));
-                } else {
-                    text = text.Replace(@"$$FWHEEL_FILTER_NAME$$", DoUrlEncode(urlEncode, "----"));
-                    text = text.Replace(@"$$FWHEEL_FILTER_POS$$", DoUrlEncode(urlEncode, "--"));
-                }
+                text = text.Replace(@"$$FWHEEL_FILTER_NAME$$", string.IsNullOrEmpty(fwheel?.SelectedFilter?.Name ?? string.Empty) ?
+                        DoUrlEncode(urlEncode, "----") :
+                        DoUrlEncode(urlEncode, fwheel.SelectedFilter.Name));
+
+                text = text.Replace(@"$$FWHEEL_FILTER_POS$$", (fwheel?.SelectedFilter?.Position ?? -1) < 0 ?
+                        DoUrlEncode(urlEncode, "--") :
+                        DoUrlEncode(urlEncode, fwheel.SelectedFilter.Position.ToString(culture)));
+
             } else {
                 var pattern = new Regex(@"\$\$FWHEEL_[A-Z0-9_]+\$\$", RegexOptions.Compiled);
                 text = pattern.Replace(text, DoUrlEncode(urlEncode, "----"));

--- a/Utilities/Utilities.cs
+++ b/Utilities/Utilities.cs
@@ -139,11 +139,11 @@ namespace DaleGhent.NINA.GroundStation.Utilities {
             if (fwheel.Connected) {
                 text = text.Replace(@"$$FWHEEL_NAME$$", DoUrlEncode(urlEncode, fwheel.Name));
 
-                text = text.Replace(@"$$FWHEEL_FILTER_NAME$$", string.IsNullOrEmpty(fwheel?.SelectedFilter?.Name ?? string.Empty) ?
+                text = text.Replace(@"$$FWHEEL_FILTER_NAME$$", string.IsNullOrEmpty(fwheel.SelectedFilter?.Name ?? string.Empty) ?
                         DoUrlEncode(urlEncode, "----") :
                         DoUrlEncode(urlEncode, fwheel.SelectedFilter.Name));
 
-                text = text.Replace(@"$$FWHEEL_FILTER_POS$$", (fwheel?.SelectedFilter?.Position ?? -1) < 0 ?
+                text = text.Replace(@"$$FWHEEL_FILTER_POS$$", (fwheel.SelectedFilter?.Position ?? -1) < 0 ?
                         DoUrlEncode(urlEncode, "--") :
                         DoUrlEncode(urlEncode, fwheel.SelectedFilter.Position.ToString(culture)));
 


### PR DESCRIPTION
Added check for `null` value of `fwheel.SelectedFilter`.
- This property can be `null` on a connected filter wheel that does not report its position on connection.
- The property will have a non `null` value after a filter selection event.

NOTE: Un-tested code, please verify prior to merge. :)